### PR TITLE
Fix #22

### DIFF
--- a/src/main/java/com/ccr4ft3r/actionsofstamina/util/PlayerUtil.java
+++ b/src/main/java/com/ccr4ft3r/actionsofstamina/util/PlayerUtil.java
@@ -1,7 +1,7 @@
 package com.ccr4ft3r.actionsofstamina.util;
 
 import com.alrex.parcool.common.action.impl.Crawl;
-import com.alrex.parcool.common.capability.impl.Parkourability;
+import com.alrex.parcool.common.capability.Parkourability;
 import com.ccr4ft3r.actionsofstamina.config.ActionType;
 import com.ccr4ft3r.actionsofstamina.config.AoSAction;
 import com.ccr4ft3r.actionsofstamina.data.ServerPlayerData;


### PR DESCRIPTION
A refactor in ParCool's Parkourability class path has caused the mod to crash on a player tick, so a change in it's import is necessary.